### PR TITLE
Exit status reflects HTTP error

### DIFF
--- a/main.go
+++ b/main.go
@@ -462,6 +462,10 @@ func main() {
 			os.Stdout.Write([]byte{'\n', '\n'})
 		}
 	}
+
+	if response.StatusCode >= 400 {
+		os.Exit(response.StatusCode - 399)
+	}
 }
 
 func printJSON(depth int, val interface{}, isKey bool) {


### PR DESCRIPTION
For any HTTP status code >= 400 we return an exit code > 0